### PR TITLE
Remove separator functionality from CollectionViewLayouts

### DIFF
--- a/Development/Development/BookCollectionView.swift
+++ b/Development/Development/BookCollectionView.swift
@@ -20,15 +20,7 @@ struct BookCollectionViewSingleSection: View, PreviewProvider {
     var body: some View {
       CollectionView(
         layout: .list
-          .contentPadding(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-          .separator(
-            separator: {
-              RoundedRectangle(cornerRadius: 8)
-                .fill(.secondary)
-                .frame(height: 8)
-                .padding(.horizontal, 20)
-            }
-          ),
+          .contentPadding(.init(top: 0, leading: 0, bottom: 0, trailing: 0)),
         content: {
           SelectableForEach(
             data: Item.mock(),
@@ -170,12 +162,7 @@ struct BookCollectionViewCombined: View, PreviewProvider {
 
     var body: some View {
       CollectionView(
-        layout: .list.separator {
-          RoundedRectangle(cornerRadius: 8)
-            .fill(.secondary)
-            .frame(height: 2)
-            .padding(.horizontal, 20)
-        },
+        layout: .list,
         content: {
           SelectableForEach(
             data: Item.mock(),
@@ -207,12 +194,7 @@ struct BookCollectionViewCombined: View, PreviewProvider {
     var body: some View {
 
       CollectionView(
-        layout: .list.separator {
-          RoundedRectangle(cornerRadius: 8)
-            .fill(.secondary)
-            .frame(height: 2)
-            .padding(.horizontal, 20)
-        },
+        layout: .list,
         content: {
           SelectableForEach(
             data: Item.mock(),

--- a/Sources/CollectionView/CollectionViewLayout.swift
+++ b/Sources/CollectionView/CollectionViewLayout.swift
@@ -40,7 +40,7 @@ public enum CollectionViewLayouts {
     }
   }
 
-  public struct List<Separator: View>: CollectionViewLayoutType {
+  public struct List: CollectionViewLayoutType {
 
     public let direction: CollectionViewListDirection
 
@@ -48,36 +48,16 @@ public enum CollectionViewLayouts {
 
     public var contentPadding: EdgeInsets
 
-    private let separator: Separator
 
-    public init(
-      direction: CollectionViewListDirection,
-      contentPadding: EdgeInsets = .init(),
-      @ViewBuilder separator: () -> Separator
-    ) {
-      self.direction = direction
-      self.contentPadding = contentPadding
-      self.separator = separator()
-    }
 
     public init(
       direction: CollectionViewListDirection,
       contentPadding: EdgeInsets = .init()
-    ) where Separator == EmptyView {
+    ) {
       self.direction = direction
       self.contentPadding = contentPadding
-      self.separator = EmptyView()
     }
 
-    public func separator<NewSeparator: View>(
-      @ViewBuilder separator: () -> NewSeparator
-    ) -> List<NewSeparator> {
-      .init(
-        direction: direction,
-        contentPadding: contentPadding,
-        separator: separator
-      )
-    }
 
     public consuming func contentPadding(_ contentPadding: EdgeInsets) -> Self {
 
@@ -99,54 +79,20 @@ public enum CollectionViewLayouts {
 
         ScrollView(.vertical, showsIndicators: showsIndicators) {
 
-          if separator is EmptyView {
-            LazyVStack {
-              content
-            }
-            .padding(contentPadding)
-          } else {
-            UnaryViewReader(readingContent: content) { children in
-              let last = children.last?.id
-              LazyVStack {
-                ForEach(children) { child in
-                  child
-                  if child.id != last {
-                    separator
-                      ._identified(by: "separator-\(child.id)")
-                  }
-                }
-              }
-            }
-            .padding(contentPadding)
+          LazyVStack {
+            content
           }
+          .padding(contentPadding)
         }
 
       case .horizontal:
 
         ScrollView(.horizontal, showsIndicators: showsIndicators) {
 
-          if separator is EmptyView {
-            LazyHStack {
-              content
-            }
-            .padding(contentPadding)
-
-          } else {
-
-            UnaryViewReader(readingContent: content) { children in
-              let last = children.last?.id
-              LazyHStack {
-                ForEach(children) { child in
-                  child
-                  if child.id != last {
-                    separator
-                      ._identified(by: "separator-\(child.id)")
-                  }
-                }
-              }
-            }
-            .padding(contentPadding)
+          LazyHStack {
+            content
           }
+          .padding(contentPadding)
         }
 
       }
@@ -226,7 +172,7 @@ public enum CollectionViewLayouts {
 
 }
 
-extension CollectionViewLayoutType where Self == CollectionViewLayouts.List<EmptyView> {
+extension CollectionViewLayoutType where Self == CollectionViewLayouts.List {
 
   public static var list: Self {
     CollectionViewLayouts.List(


### PR DESCRIPTION
## Summary
- Removed the separator feature from `CollectionViewLayouts.List` to simplify the API
- Users can still implement separators directly in their content if needed

## Changes
- Remove generic `Separator` type parameter from `List` struct
- Remove `separator` property and all separator-related initializers
- Simplify `body` implementation to always use `LazyVStack`/`LazyHStack` without separator logic
- Update extension to work with non-generic `List` type
- Update development examples that were using separators

## Test plan
- [x] Swift package builds successfully
- [x] Development app builds and runs without errors
- [x] All separator usage has been removed from examples

🤖 Generated with [Claude Code](https://claude.ai/code)